### PR TITLE
Added `entity_id` option and states; bumped version to 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Kodi's recently added media.
 
 ### Platform Options:
 
+#### Variant №1
 | key | default | required | description
 | --- | --- | --- | ---
 | host | localhost | no | The host Kodi is running on.
@@ -33,6 +34,11 @@ Kodi's recently added media.
 | tcp_port | 9090 | no | The TCP port number. Used for WebSocket connections to Kodi.
 | username | | no | The Kodi HTTP username.
 | password | | no | The Kodi HTTP password.
+
+#### Variant №2
+| key | default | required | description
+| --- | --- | --- | ---
+| entity_id | | yes | Entity ID of a Kodi `media_player` entity
 
 ### Sample for configuration.yaml:
 
@@ -42,6 +48,9 @@ Kodi's recently added media.
       host: YOUR_KODI_HOST
       password: YOUR_KODI_PASSWORD
       port: YOUR_KODI_PORT
+
+    - platform: kodi_recently_added
+      entity_id: YOUR_KODI_ENTITY_ID
 
 ### Sample for ui-lovelace.yaml:
 

--- a/custom_components/kodi_recently_added/sensor.py
+++ b/custom_components/kodi_recently_added/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.restore_state import RestoreEntity
 
 
 __version__ = '0.2.7'

--- a/custom_components/kodi_recently_added/sensor.py
+++ b/custom_components/kodi_recently_added/sensor.py
@@ -4,29 +4,42 @@ from urllib import parse
 
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
+from homeassistant.const import STATE_ON, STATE_OFF, CONF_ENTITY_ID, STATE_PROBLEM, STATE_UNKNOWN, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+
 try:
-    # Pre v0.91
-    from homeassistant.components.media_player.kodi import (
-        CONF_TCP_PORT, DEFAULT_TCP_PORT, KodiDevice)
-except ImportError:
     # >= v0.91
     from homeassistant.components.kodi.media_player import (
-        CONF_TCP_PORT, DEFAULT_TCP_PORT, KodiDevice)
+            CONF_TCP_PORT, DEFAULT_TCP_PORT, KodiDevice, EVENT_KODI_CALL_METHOD_RESULT,
+            SERVICE_CALL_METHOD, DOMAIN as KODI_DOMAIN)
+    try:
+        # >= v0.98
+        from homeassistant.components.kodi import ATTR_METHOD
+    except ImportError:
+        from homeassistant.components.kodi.media_player import ATTR_METHOD
+except ImportError:
+    # Pre v0.91
+    from homeassistant.components.media_player.kodi import (
+        CONF_TCP_PORT, DEFAULT_TCP_PORT, KodiDevice, EVENT_KODI_CALL_METHOD_RESULT,
+        SERVICE_CALL_METHOD, DOMAIN as KODI_DOMAIN, ATTR_METHOD)
+
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 
-__version__ = '0.2.7'
+__version__ = '0.2.8'
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+PLATFORM_SCHEMA = vol.Any(PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=8080): cv.port,
     vol.Optional(CONF_TCP_PORT, default=DEFAULT_TCP_PORT): cv.port,
     vol.Inclusive(CONF_USERNAME, 'auth'): cv.string,
     vol.Inclusive(CONF_PASSWORD, 'auth'): cv.string,
-})
+}), PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ENTITY_ID): cv.entity_id
+}))
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -41,15 +54,24 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 class KodiMediaSensor(RestoreEntity):
 
+    properties = NotImplemented
+    update_method = NotImplemented
+    result_key = NotImplemented
+
     def __init__(self, hass, config):
-        self.kodi = KodiDevice(
-            hass, self.name, config.get(CONF_HOST), config.get(CONF_PORT),
-            config.get(CONF_TCP_PORT), username=config.get(CONF_USERNAME),
-            password=config.get(CONF_PASSWORD))
+        if CONF_ENTITY_ID in config:
+            self.kodi = config[CONF_ENTITY_ID]
+        else:
+            self.kodi = KodiDevice(
+                hass, self.name, config.get(CONF_HOST), config.get(CONF_PORT),
+                config.get(CONF_TCP_PORT), username=config.get(CONF_USERNAME),
+                password=config.get(CONF_PASSWORD))
         self._state = None
         self.data = []
         self.base_web_url = 'http://{}:{}/image/image%3A%2F%2F'.format(
             config.get(CONF_HOST), config.get(CONF_PORT))
+
+        hass.bus.async_listen(EVENT_KODI_CALL_METHOD_RESULT, self._handle_update_event)
 
     @property
     def state(self):
@@ -72,6 +94,51 @@ class KodiMediaSensor(RestoreEntity):
         quoted_path = parse.quote(parse.quote(path, safe=''))
         return self.base_web_url + quoted_path
 
+    def _handle_result(self, result):
+        error = result.get('error')
+        if error:
+            _LOGGER.error('Error while fetching %s: [%d] %s' % (self.result_key, error.get('code'), error.get('message')))
+            self._state = STATE_PROBLEM
+            return
+
+        new_data = result.get(self.result_key, [])
+        
+        if not new_data:
+            _LOGGER.warning('No %s found after requesting data from Kodi, assuming empty.' % self.result_key)
+            self._state = STATE_UNKNOWN
+            return
+        
+        self.data = new_data
+        self._state = STATE_ON
+
+    async def _handle_update_event(self, event):
+        """Handle update event after Kodi finishes replying."""
+        if event.data['input'][ATTR_METHOD] == self.update_method:
+            if event.data['result_ok']:
+                self._handle_result(event.data['result'])
+            else:
+                self._state = STATE_OFF
+            await self.async_update_ha_state()
+    
+    async def async_update(self):
+        if isinstance(self.kodi, KodiDevice):
+            result = await self.kodi.async_call_method(self.update_method, properties=self.properties)
+            if result:
+                self._handle_result(result)
+            else:
+                self._state = STATE_OFF
+        else:
+            media_player_state = self.hass.states.get(self.kodi)
+            if media_player_state is None or media_player_state.state in (STATE_OFF, STATE_UNAVAILABLE):
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_ON
+                await self.hass.services.async_call(KODI_DOMAIN, SERVICE_CALL_METHOD, {
+                    ATTR_ENTITY_ID: self.kodi,
+                    ATTR_METHOD: self.update_method,
+                    'properties': self.properties,
+                })
+
 
 class KodiRecentlyAddedTVSensor(KodiMediaSensor):
 
@@ -79,6 +146,8 @@ class KodiRecentlyAddedTVSensor(KodiMediaSensor):
         'art', 'dateadded', 'episode', 'fanart', 'firstaired', 'playcount',
         'rating', 'runtime', 'season', 'showtitle', 'title'
     ]
+    update_method = 'VideoLibrary.GetRecentlyAddedEpisodes'
+    result_key = 'episodes'
 
     @property
     def name(self):
@@ -129,24 +198,14 @@ class KodiRecentlyAddedTVSensor(KodiMediaSensor):
         attrs['data'] = json.dumps(card_json)
         return attrs
 
-    async def async_update(self):
-        result = await self.kodi.async_call_method(
-            'VideoLibrary.GetRecentlyAddedEpisodes',
-            properties=self.properties)
-        if result:
-            episodes = result.get('episodes', [])
-            
-            if not episodes:
-                _LOGGER.warning('No episodes found after requesting data from Kodi.')
-            
-            self.data = episodes
-
 
 class KodiRecentlyAddedMoviesSensor(KodiMediaSensor):
 
     properties = [
         'art', 'dateadded', 'genre', 'playcount', 'premiered', 'rating',
         'runtime', 'studio', 'title']
+    update_method = 'VideoLibrary.GetRecentlyAddedMovies'
+    result_key = 'movies'
 
     @property
     def name(self):
@@ -194,13 +253,3 @@ class KodiRecentlyAddedMoviesSensor(KodiMediaSensor):
             card_json.append(card)
         attrs['data'] = json.dumps(card_json)
         return attrs
-
-    async def async_update(self):
-        result = await self.kodi.async_call_method(
-            'VideoLibrary.GetRecentlyAddedMovies', properties=self.properties)
-        if result:
-            try:
-                self.data = result['movies']
-            except KeyError:
-                _LOGGER.exception(
-                    'Unexpected result while fetching movies: %s', result)

--- a/custom_components/kodi_recently_added/sensor.py
+++ b/custom_components/kodi_recently_added/sensor.py
@@ -15,7 +15,6 @@ except ImportError:
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.restore_state import RestoreEntity
 
 
@@ -40,7 +39,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(sensors, True)
 
 
-class KodiMediaSensor(Entity, RestoreEntity):
+class KodiMediaSensor(RestoreEntity):
 
     def __init__(self, hass, config):
         self.kodi = KodiDevice(

--- a/custom_components/kodi_recently_added/sensor.py
+++ b/custom_components/kodi_recently_added/sensor.py
@@ -39,7 +39,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(sensors, True)
 
 
-class KodiMediaSensor(Entity):
+class KodiMediaSensor(Entity, RestoreEntity):
 
     def __init__(self, hass, config):
         self.kodi = KodiDevice(

--- a/custom_components/kodi_recently_added/sensor.py
+++ b/custom_components/kodi_recently_added/sensor.py
@@ -134,11 +134,12 @@ class KodiRecentlyAddedTVSensor(KodiMediaSensor):
             'VideoLibrary.GetRecentlyAddedEpisodes',
             properties=self.properties)
         if result:
-            try:
-                self.data = result['episodes']
-            except KeyError:
-                _LOGGER.exception(
-                    'Unexpected result while fetching tv shows: %s', result)
+            episodes = result.get('episodes', [])
+            
+            if not episodes:
+                _LOGGER.warning('No episodes found after requesting data from Kodi.')
+            
+            self.data = episodes
 
 
 class KodiRecentlyAddedMoviesSensor(KodiMediaSensor):


### PR DESCRIPTION
also:
- Reduced the severity of errors when data cannot be retrieved from Kodi when it doesn't have any shows or movies in its library
- Refactored calls to have a unified update procedure
- States reflect what happens with the sensor (`on` for normal operation, `off` for mirroring Kodi state, `problem` for errors encountered on request i.e. API incompatibility, `unknown` for receiving Kodi data without any movies/TV shows)
- Added `RestoreEntity` as the base for the sensors so that the card doesn't disappear without a trace on restart